### PR TITLE
Add note about TS-Convert script to README

### DIFF
--- a/MobProgramming.md
+++ b/MobProgramming.md
@@ -4,8 +4,8 @@ This session is intended to help us understand how you would approach a very com
 
 There are two main tasks:
 
-- Pull down a list of cars from an API endpoint and display them to the user
-- Create a form that sends a POST request to the API, creating a new car. (Ideally the UI will update without refreshing)
+-   Pull down a list of cars from an API endpoint and display them to the user
+-   Create a form that sends a POST request to the API, creating a new car. (Ideally the UI will update without refreshing)
 
 This session is run as a [mob programming session](https://en.wikipedia.org/wiki/Mob_programming), and the end result is less important than the process - we're looking for people who communicate well, are empathetic towards their colleagues, and look for opportunities to share knowledge.
 
@@ -21,16 +21,16 @@ You'll be joined on the call by a couple of front-end engineers from Arnold Clar
 
 If you would like to "drive" the machine, we have a couple of options:
 
-- The best option is to download and set up the [Live Share extension for Visual Studio Code](https://code.visualstudio.com/learn/collaboration/live-share).
-- We can also share screen control using Microsoft Teams, but this isn't ideal as it can be a little bit laggy.
+-   The best option is to download and set up the [Live Share extension for Visual Studio Code](https://code.visualstudio.com/learn/collaboration/live-share).
+-   We can also share screen control using Microsoft Teams, but this isn't ideal as it can be a little bit laggy.
 
 If you would prefer not to drive the machine, that's perfectly fine. It won't have an impact on your application.
 
 ### Language
 
-You can choose to use either TypeScript or JavaScript for this task. 
+You can choose to use either TypeScript or JavaScript for this task.
 
-TypeScript is set up, so if you would like to use it, just rename any files using TypeScript to .ts or .tsx. You can place any types in `/src/types` and they will be available without needing to be imported.
+TypeScript is set up, so if you would like to use it, run `npm run convert-ts` to change the extension of JavaScript files in the `src` folder to `.tsx`. You can then place any types in `/src/types` and they will be available without needing to be imported.
 
 If you would like to use JavaScript, no changes are needed.
 
@@ -38,10 +38,10 @@ If you would like to use JavaScript, no changes are needed.
 
 To run this app:
 
-- First, run `npm install`
-- Then, start the API by running `npm run start:api`
-- You can then start the app by running `npm start` and visiting [localhost:8080](http://localhost:8080).
-- You can run tests with `npm test`; these are set up with [Jest](https://jestjs.io/) and [Testing Library](https://testing-library.com/docs/react-testing-library/intro/).
+-   First, run `npm install`
+-   Then, start the API by running `npm run start:api`
+-   You can then start the app by running `npm start` and visiting [localhost:8080](http://localhost:8080).
+-   You can run tests with `npm test`; these are set up with [Jest](https://jestjs.io/) and [Testing Library](https://testing-library.com/docs/react-testing-library/intro/).
 
 ## Resources
 
@@ -51,7 +51,7 @@ You can also use any libraries you want - we would love to find out what your us
 
 We've set up some things to get started:
 
-- A minimal React / Webpack app
-- A `CarForm` component with inputs for make, model, registration, and price
-- An API, which uses [json-server](https://github.com/typicode/json-server). (Check out [`./requests.http`](https://github.com/arnoldclark/front-end-mob-programming/blob/main/requests.http) to get started)
-- [Chassis](https://arnoldclark.github.io/chassis/), our CSS framework. (We'll help you with this, of course!)
+-   A minimal React / Webpack app
+-   A `CarForm` component with inputs for make, model, registration, and price
+-   An API, which uses [json-server](https://github.com/typicode/json-server). (Check out [`./requests.http`](https://github.com/arnoldclark/front-end-mob-programming/blob/main/requests.http) to get started)
+-   [Chassis](https://arnoldclark.github.io/chassis/), our CSS framework. (We'll help you with this, of course!)


### PR DESCRIPTION
Although the mob programming exercise is set up for TypeScript, and have added a script to change JS `src` files to TS, the README still instructs candidates to manually change the extensions of the files. This PR just adds a line in to reference the fact that they can run a script to do this for them if they'd like to undertake the exercise in TypeScript.